### PR TITLE
Initial packaging of mpi3mr-8.6.1.0.0

### DIFF
--- a/SOURCES/0001-bsg-lib-pre-5.0-API.patch
+++ b/SOURCES/0001-bsg-lib-pre-5.0-API.patch
@@ -1,0 +1,54 @@
+From b58068e2990c88af616f6fcd6fa00dd0b984900e Mon Sep 17 00:00:00 2001
+From: Yann Dirson <yann.dirson@vates.fr>
+Date: Tue, 19 Sep 2023 18:05:25 +0200
+Subject: [PATCH] bsg-lib pre-5.0 API
+
+The upstream driver uses the bsg-lib API as it exists in 5.0 and later
+kernels.  It happens that the RHEL8 4.18-based kernel includes those
+changes, which allows a single driver to work with both RHEL8 and
+RHEL9 kernels.
+
+1. From commit 5e28b8d8a1b03ce86f33d38a64a4983d2b5c7679 a new
+bsg_remove_queue help is added, we just expand it to use the code its
+use replaces, from that very commit
+
+2. From commit aae3b069d5ce865ca5ef2902c2a22cef7ab4f3a2 an optional
+timeout parameter is added, which this driver does not use, so we can
+safely just drop the NULL
+
+  struct request_queue *bsg_setup_queue(struct device *dev, const char *name,
+ -		bsg_job_fn *job_fn, int dd_job_size);
+ +		bsg_job_fn *job_fn, rq_timed_out_fn *timeout, int dd_job_size);
+
+---
+ mpi3mr_app.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/mpi3mr_app.c b/mpi3mr_app.c
+index 1e69b8f..94e17ff 100755
+--- a/mpi3mr_app.c
++++ b/mpi3mr_app.c
+@@ -2922,7 +2922,10 @@ void mpi3mr_bsg_exit(struct mpi3mr_ioc *mrioc)
+ 	if (!mrioc->bsg_queue)
+ 		return;
+ 
+-	bsg_remove_queue(mrioc->bsg_queue);
++	if (mrioc->bsg_queue) {
++		bsg_unregister_queue(mrioc->bsg_queue);
++		blk_cleanup_queue(mrioc->bsg_queue);
++	}
+ 	mrioc->bsg_queue = NULL;
+ 
+ 	device_del(bsg_dev);
+@@ -2972,7 +2975,7 @@ void mpi3mr_bsg_init(struct mpi3mr_ioc *mrioc)
+ 	}
+ 
+ 	queue = bsg_setup_queue(bsg_dev, dev_name(bsg_dev),
+-			mpi3mr_bsg_request, NULL, 0);
++			mpi3mr_bsg_request, 0);
+ 	if (IS_ERR(queue)) {
+ 		ioc_err(mrioc, "%s: bsg registration failed\n",
+ 		    dev_name(bsg_dev));
+-- 
+2.30.2
+

--- a/SOURCES/mpi3mr-8.6.1.0.0-src.tar.gz
+++ b/SOURCES/mpi3mr-8.6.1.0.0-src.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd438f1c25f49bc7eb3eb9f70bf9246e986024b77265db462efcacb5c37edd1
+size 184033

--- a/SPECS/mpi3mr-module.spec
+++ b/SPECS/mpi3mr-module.spec
@@ -1,0 +1,54 @@
+%define module_dir extra
+
+Summary: Broadcom mpi3mr RAID device driver
+Name: mpi3mr-module
+Version: 8.6.1.0.0
+Release: 1%{?dist}
+License: GPL-2.0-or-later
+
+# https://www.broadcom.com/support/download-search?pg=Storage+Adapters,+Controllers,+and+ICs&pf=Storage+Adapters,+Controllers,+and+ICs&pn=MegaRAID+9670W-16i&pa=&po=&dk=&pl=&l=false
+Source: mpi3mr-%{version}-src.tar.gz
+
+Patch0: 0001-bsg-lib-pre-5.0-API.patch
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+%description
+Broadcom mpi3mr device drivers for the Linux Kernel version %{kernel_version}.
+
+%prep
+%autosetup -n mpi3mr
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) modules
+
+%install
+%{__make} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+
+# remove extra files modules_install copies in
+rm -f %{buildroot}/lib/modules/%{kernel_version}/modules.*
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+
+%changelog
+* Wed Sep 20 2023 Yann Dirson <yann.dirson@vates.tech> - 8.6.1.0.0-1
+- Initial packaging


### PR DESCRIPTION
Including "backport" from rhel8 4.18-based frankenkernel to 4.19.

From 8.6.1.0.0-1_Driver_Linux.zip with sha256sum of a2a47df87a66a4ca95c548964eaa67ce690ef0bc5255037e7bbf412f1c426c8e