### PR TITLE
DDK support

### DIFF
--- a/Makefile.ddk
+++ b/Makefile.ddk
@@ -1,0 +1,43 @@
+# begin pack-specific values
+SPEC := SPECS/mpi3mr-module.spec
+TEXT := Driver Pack for Broadcom mpi3mr RAID controler
+UUID := 0c7b6bfe-5ad9-457f-8ed4-184245f7203f
+PACK_BUILD = pack.0.1
+# key to sign update with
+GPG_KEY_FILE := RPM-GPG-KEY-XS-DDK-Test
+# end pack-specific values
+
+LABEL = $(PACKAGE_NAME)
+PACK_VERSION = $(XENSERVER_VERSION)
+
+# no changes below here
+RPM_VERSION := $(shell sed -ne 's/^Version: *//p' $(SPEC))
+RPM_RELEASE := $(shell rpm --define "_topdir $(CURDIR)" --eval $(shell sed -ne 's/^Release: *//p' $(SPEC)))
+RPMDIR := $(shell rpm --define "_topdir $(CURDIR)" --eval %{_rpmdir})
+RPMSOURCES := $(shell rpm --define "_topdir $(CURDIR)" --eval %{_sourcedir})
+ARCH := $(shell uname -p)
+XENSERVER_VERSION := $(shell . /etc/os-release ; IFS=- ; set -- $$VERSION ; echo $$1)
+PACKAGE_NAME := $(shell sed -ne 's/^Name: *//p' $(SPEC))
+ISO := $(PACKAGE_NAME)-$(RPM_VERSION)-$(RPM_RELEASE).iso
+GPG_UID = $(shell gpg --batch --with-colons $(GPG_KEY_FILE) 2>/dev/null | awk -F: '$$1=="pub" {print $$5}')
+
+RPM := $(PACKAGE_NAME)-$(RPM_VERSION)-$(RPM_RELEASE)
+RPM_FILE := $(RPM:%=$(RPMDIR)/$(ARCH)/%.$(ARCH).rpm)
+
+
+$(ISO): $(RPM_FILE) $(GPG_KEY_FILE)
+	sed -e 's/@DRIVER@/$(PACKAGE_NAME)/g' groups.xml >/tmp/groups.xml
+	build-update --uuid $(UUID) --label "$(LABEL)" --version $(PACK_VERSION).$(PACK_BUILD) \
+		--description "$(TEXT)" \
+		--groupfile /tmp/groups.xml \
+		--key "$(GPG_UID)" --keyfile $(GPG_KEY_FILE) \
+		-o $@ $(RPM_FILE)
+
+$(RPM_FILE): $(SPEC)
+	rpmbuild -bb --define "_topdir $(CURDIR)" $<
+
+$(GPG_KEY_FILE):
+	generate-test-key $@
+
+clean:
+	rm -f $(ISO)

--- a/SOURCES/0001-bsg-lib-pre-5.0-API.patch
+++ b/SOURCES/0001-bsg-lib-pre-5.0-API.patch
@@ -1,0 +1,54 @@
+From b58068e2990c88af616f6fcd6fa00dd0b984900e Mon Sep 17 00:00:00 2001
+From: Yann Dirson <yann.dirson@vates.fr>
+Date: Tue, 19 Sep 2023 18:05:25 +0200
+Subject: [PATCH] bsg-lib pre-5.0 API
+
+The upstream driver uses the bsg-lib API as it exists in 5.0 and later
+kernels.  It happens that the RHEL8 4.18-based kernel includes those
+changes, which allows a single driver to work with both RHEL8 and
+RHEL9 kernels.
+
+1. From commit 5e28b8d8a1b03ce86f33d38a64a4983d2b5c7679 a new
+bsg_remove_queue help is added, we just expand it to use the code its
+use replaces, from that very commit
+
+2. From commit aae3b069d5ce865ca5ef2902c2a22cef7ab4f3a2 an optional
+timeout parameter is added, which this driver does not use, so we can
+safely just drop the NULL
+
+  struct request_queue *bsg_setup_queue(struct device *dev, const char *name,
+ -		bsg_job_fn *job_fn, int dd_job_size);
+ +		bsg_job_fn *job_fn, rq_timed_out_fn *timeout, int dd_job_size);
+
+---
+ mpi3mr_app.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/mpi3mr_app.c b/mpi3mr_app.c
+index 1e69b8f..94e17ff 100755
+--- a/mpi3mr_app.c
++++ b/mpi3mr_app.c
+@@ -2922,7 +2922,10 @@ void mpi3mr_bsg_exit(struct mpi3mr_ioc *mrioc)
+ 	if (!mrioc->bsg_queue)
+ 		return;
+ 
+-	bsg_remove_queue(mrioc->bsg_queue);
++	if (mrioc->bsg_queue) {
++		bsg_unregister_queue(mrioc->bsg_queue);
++		blk_cleanup_queue(mrioc->bsg_queue);
++	}
+ 	mrioc->bsg_queue = NULL;
+ 
+ 	device_del(bsg_dev);
+@@ -2972,7 +2975,7 @@ void mpi3mr_bsg_init(struct mpi3mr_ioc *mrioc)
+ 	}
+ 
+ 	queue = bsg_setup_queue(bsg_dev, dev_name(bsg_dev),
+-			mpi3mr_bsg_request, NULL, 0);
++			mpi3mr_bsg_request, 0);
+ 	if (IS_ERR(queue)) {
+ 		ioc_err(mrioc, "%s: bsg registration failed\n",
+ 		    dev_name(bsg_dev));
+-- 
+2.30.2
+

--- a/SOURCES/mpi3mr-8.6.1.0.0-src.tar.gz
+++ b/SOURCES/mpi3mr-8.6.1.0.0-src.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd438f1c25f49bc7eb3eb9f70bf9246e986024b77265db462efcacb5c37edd1
+size 184033

--- a/SPECS/mpi3mr-module.spec
+++ b/SPECS/mpi3mr-module.spec
@@ -1,0 +1,54 @@
+%define module_dir extra
+
+Summary: Driver for mpi3mr-module
+Name: mpi3mr-module
+Version: 8.6.1.0.0
+Release: 0%{?dist}
+License: GPL-2.0-or-later
+
+# https://www.broadcom.com/support/download-search?pg=Storage+Adapters,+Controllers,+and+ICs&pf=Storage+Adapters,+Controllers,+and+ICs&pn=MegaRAID+9670W-16i&pa=&po=&dk=&pl=&l=false
+Source: mpi3mr-%{version}-src.tar.gz
+
+Patch0: 0001-bsg-lib-pre-5.0-API.patch
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+%description
+Broadcom mpi3mr device drivers for the Linux Kernel version %{kernel_version}.
+
+%prep
+%autosetup -n mpi3mr
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) modules
+
+%install
+%{__make} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+
+# remove extra files modules_install copies in
+rm -f %{buildroot}/lib/modules/%{kernel_version}/modules.*
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+
+%changelog
+* Wed Sep 20 2023 Yann Dirson <yann.dirson@vates.tech> - 8.6.1.0.0-0
+- Initial beta packaging

--- a/groups.xml
+++ b/groups.xml
@@ -1,0 +1,23 @@
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+<comps>
+  <group>
+   <id>update</id>
+   <default>False</default>
+   <uservisible>True</uservisible>
+   <name>Driver Update</name>
+   <description></description>
+    <packagelist>
+      <packagereq type="mandatory">update-@DRIVER@</packagereq>
+    </packagelist>
+  </group>
+  <group>
+   <id>drivers</id>
+   <default>False</default>
+   <uservisible>True</uservisible>
+   <name>Host Installer Driver Update</name>
+   <description></description>
+    <packagelist>
+      <packagereq type="mandatory">update-@DRIVER@</packagereq>
+    </packagelist>
+  </group>
+</comps>


### PR DESCRIPTION
This PR adds just 2 files to allow for generation of a Driver Disk using the DDK packages from XS, which would need to be officialized in XCP-ng first.

This was simplified as compared with a CH driver disk: there is no `control-*` rpm, which was only useful to constraint the pack installation to a specific `product-version`, which has no appeal to us.  The `update-*` package is OTOH not possible to get rid off without modifying `host-installer`, so we live with it.

The Makefile sure looks much like a template with a few variables customized for the package, and instead separating the template would compare like:
pros:
- less duplication between ddk-enabled driver packages
- closer to upstream CH/XS
cons:
- it would anyway be necessary to keep the data to fill the template, and to track pack versioning
- would add work for a feature whose future in this form is uncertain